### PR TITLE
feat: add flag for subdirectory (for monorepos)

### DIFF
--- a/mkgendocs/gendocs.py
+++ b/mkgendocs/gendocs.py
@@ -6,6 +6,7 @@ from mkgendocs.parse import GoogleDocString, Extract
 import argparse
 from mako.template import Template
 import logging
+from typing import Tuple, Dict, List, Union
 
 logging.basicConfig(level=logging.INFO,
                     format=">%(message)s")
@@ -57,10 +58,14 @@ ${section['text']}
 """
 
 
-def copy_examples(examples_dir, destination_dir):
+def copy_examples(examples_dir: str, destination_dir: str) -> None:
     """Copy the examples directory in the documentation.
 
     Prettify files by extracting the docstrings written in Markdown.
+
+    Args:
+        examples_dir (str): The directory where the examples are stored.
+        destination_dir (str): The directory where the examples will be copied to.
     """
     pathlib.Path(destination_dir).mkdir(exist_ok=True)
     for file in os.listdir(examples_dir):
@@ -93,18 +98,17 @@ def copy_examples(examples_dir, destination_dir):
             f_out.write('```')
 
 
-def to_markdown(target_info, template, rel_path, config):
-    """ converts object data and docstring to markdown
+def to_markdown(target_info: Dict, template: Template, rel_path: str, config: Dict) -> str:
+    """Converts object data and docstring to markdown
 
     Args:
-        target_info: object name, signature, and docstring
-        template: markdown template for docstring to be rendered in markdown
-        rel_path: relative path to current class sources
-        config: mkgendocs config dict
+        target_info (Dict): Object name, signature, and docstring
+        template (Template): Markdown template for docstring to be rendered in markdown
+        rel_path (str): Relative path to current class sources
+        config (Dict): mkgendocs config dict
 
     Returns:
-        markdown (str): a string with the object documentation rendered in markdown
-
+        str: A string with the object documentation rendered in markdown
     """
     docstring = target_info['docstring']
     docstring_parser = GoogleDocString(docstring)
@@ -130,7 +134,8 @@ def to_markdown(target_info, template, rel_path, config):
     if "custom_repo" in config:
         repo = os.path.join(config['custom_repo'], rel_path, lineno)
     elif "repo" in config:
-        repo = os.path.join(config['repo'], "blob", config.get('version', 'master'), rel_path, lineno)
+        sub_dir = config.get("sub_dir", "")
+        repo = os.path.join(config['repo'], "blob", config.get('version', 'master'), sub_dir, rel_path, lineno)
 
     if repo is not None:
         # in mako ## is a comment
@@ -189,11 +194,16 @@ def build_index(pages):
     return class_index, function_index
 
 
-def generate(config_path):
-    """Generates the markdown files for the documentation.
+def generate(config_path: str) -> None:
+    """
+    Generates the markdown files for the documentation.
 
-    # Arguments
-        sources_dir: Where to put the markdown files.
+    Args:
+        config_path (str): The path to the configuration file.
+
+    Raises:
+        Exception: If the configuration file is invalid.
+        FileNotFoundError: If the template directory does not exist.
     """
 
     root = pathlib.Path().absolute()

--- a/mkgendocs/parse.py
+++ b/mkgendocs/parse.py
@@ -44,10 +44,11 @@ class DocString(object):
             documentation if they are part of this list. Defaults to `['self']`.
     """
 
-    def __init__(self, docstring, signature=None, config=None):
+    def __init__(self, docstring: str, signature: dict = None, config: dict = None):
         """
         Initialize a new parser.
         Args:
+            docstring (str): Docstring to be parsed.
             signature(dict, optional): A dict containing arguments and return
                 annotations. See the function `parse_signature' to construct
                 this dict from a PEP484 annotated signature. When this argument
@@ -95,7 +96,7 @@ class DocString(object):
         }
         self._re = {}
 
-    def parse(self):
+    def parse(self) -> list:
         """
         This method should be overridden to parse docstring sections
         """
@@ -128,9 +129,12 @@ class DocString(object):
         """
         pass
 
-    def __json__(self):
+    def __json__(self) -> str:
         """
         Output docstring as JSON data.
+
+        Returns:
+            str: The docstring data in JSON format.
         """
         import json
 
@@ -141,26 +145,32 @@ class DocString(object):
 
     def __str__(self):
         """
-        This method should be overloaded to specify how to output to plain-text.
+        Output the original docstring.
+
+        Returns:
+            str: The original docstring.
         """
         return self.docstring
 
-    def markdown(self):
+    def markdown(self) -> tuple:
         """
         Output data relevant data needed for markdown rendering.
         Args:
             filename (str, optional) : select template to use for markdown
                 rendering.
+        Returns:
+            tuple: Headers and data for markdown rendering.
         """
         data = self.data
         headers = self._config['headers'].split('|')
         return headers, data
 
-    def check_args(self, section):
+    def check_args(self, section: dict):
         """
-        Check if all args have been documented in the docstring and if, they
-        have annotations, annotations matches the ones in the function
-        signature. This method only works when `signature` have been specified.
+        Check if all args have been documented in the docstring and if they have annotations, annotations matches the ones in the function signature. 
+
+        Args:
+            section (dict): The section of the docstring to check.
         """
         if not self.signature or not self._config['check_args']:
             return
@@ -192,11 +202,15 @@ class DocString(object):
                 if arg not in self.signature['args']:
                     warnings.warn(' Found argument `%s` in docstring that does' \
                                   ' not exist in function signature.' % arg, UserWarning)
-
-    def override_annotations(self, section, parsed_args, headers):
+    
+    def override_annotations(self, section: dict, parsed_args: dict, headers: list):
         """
-        Override argument annotations in docstrings with annotations found in
-        `args`.
+        Override argument annotations in docstrings with annotations found in `args`.
+
+        Args:
+            section (dict): The section of the docstring to override.
+            parsed_args (dict): The parsed arguments.
+            headers (list): The headers.
         """
         if not parsed_args or not self._config['override_annotations']:
             return
@@ -212,10 +226,12 @@ class DocString(object):
                 out['signature'] = parsed_args[arg['field']]
             section['args'].append(out)
 
-    def mark_code_blocks(self, section):
+    def mark_code_blocks(self, section: dict):
         """
-        Enclose code blocks in formatting tags if option `config['code']` is
-        not None.
+        Enclose code blocks in formatting tags if option `config['code']` is not None.
+
+        Args:
+            section (dict): The section of the docstring to mark.
         """
         if not self._config['code']:
             return


### PR DESCRIPTION
There are some unrelated AI suggested type/docstring changes.

The core new functionality is the use of a subdirectory within a repo, ex in mono repos that house both service code and library code

Core change:
``` python
 sub_dir = config.get("sub_dir", "")
 repo = os.path.join(config['repo'], "blob", config.get('version', 'master'), sub_dir, rel_path, lineno)
```
New config parameter:
```
sources_dir: docs/sources
templates_dir: docs/templates
repo: https://github.com/user/repo  # link to sources on github
sub_dir: src/pyrex                              # prepended before relative path but after branch/version
version: main        
```
